### PR TITLE
feat: Add and prioritize claude opus support via env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.19.0",
     "@nextui-org/react": "^2.2.10",
     "ai": "^3.0.9",
     "framer-motion": "^11.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@anthropic-ai/sdk':
+    specifier: ^0.19.0
+    version: 0.19.0
   '@nextui-org/react':
     specifier: ^2.2.10
     version: 2.2.10(@types/react@18.2.65)(framer-motion@11.0.12)(react-dom@18.2.0)(react@18.2.0)(tailwind-variants@0.2.0)(tailwindcss@3.4.1)
@@ -62,6 +65,22 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+    dev: false
+
+  /@anthropic-ai/sdk@0.19.0:
+    resolution: {integrity: sha512-mv4JtBGLKtpi7XK6Car2Tb+xwdgOuaMtRxxJoO27tqFESgGWdlxSWU65ntjIXAFFLABbRCtVFsnXTBS1AlF6NQ==}
+    dependencies:
+      '@types/node': 18.19.23
+      '@types/node-fetch': 2.6.11
+      abort-controller: 3.0.0
+      agentkeepalive: 4.5.0
+      digest-fetch: 1.3.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+      web-streams-polyfill: 3.3.3
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /@babel/helper-string-parser@7.23.4:

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,28 +1,43 @@
 import OpenAI from "openai";
-import { OpenAIStream, StreamingTextResponse } from "ai";
+import Anthropic from "@anthropic-ai/sdk";
+import { OpenAIStream, StreamingTextResponse, AnthropicStream } from "ai";
 
-// Create an OpenAI API client (that's edge friendly!)
+// Create an OpenAI and Anthropic API clients (that're edge friendly!)
+export const runtime = "edge";
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
-export const runtime = "edge";
+const anthropic = new Anthropic({});
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
+  // Prioritize Claude Opus usage for higher generation quality:
+  const shouldUseAnthropicClaude = process.env.ANTHROPIC_API_KEY;
+
+  // If we have an Anthropic API key, prioritize Claude to generate the response:
+  if (shouldUseAnthropicClaude) {
+    // Ask Anthropic for a streaming chat completion given the prompt:
+    const stream = await anthropic.messages.create({
+      messages,
+      model: "claude-3-opus-20240229",
+      max_tokens: 2048,
+      stream: true,
+    });
+
+    // Convert into ReadableStream and respond:
+    return new StreamingTextResponse(AnthropicStream(stream));
+  }
 
   // Heuristic to choose model, gpt-4 can only take 8k tokens in total:
   const shouldUseLargerContextModel = messages[0].content.length > 12000;
 
-  // Ask OpenAI for a streaming chat completion given the prompt
+  // Ask OpenAI for a streaming chat completion given the prompt:
   const response = await openai.chat.completions.create({
     model: shouldUseLargerContextModel ? "gpt-4-1106-preview" : "gpt-4",
     stream: true,
     messages,
   });
 
-  // Convert the response into a text-stream
-  const stream = OpenAIStream(response);
-
-  // Respond with the stream
-  return new StreamingTextResponse(stream);
+  // Convert into ReadableStream and respond:
+  return new StreamingTextResponse(OpenAIStream(response));
 }


### PR DESCRIPTION
Adds support for generations using Claude Opus

* Uses anthropic client for generations if key is available on `process.env`
* Allows same streaming response interface via next/ai conversion to ReadableStream from anthropic SDK response